### PR TITLE
Fixed fake tensor output size

### DIFF
--- a/examples/pytorch/cuembed_pyt.py
+++ b/examples/pytorch/cuembed_pyt.py
@@ -51,6 +51,9 @@ def cuemb_embedding(
 
 @cuemb_embedding.register_fake
 def _(params : torch.Tensor, idx : torch.Tensor, offsets : torch.Tensor, weights : torch.Tensor = None):
-  return torch.empty_like(params).reshape([offsets.shape[0]-1, params.shape[1]])
+  batch_size = offsets.shape[0] - 1
+  embedding_dim = params.shape[1]
+  return torch.empty((batch_size, embedding_dim), device=params.device, dtype=params.dtype)
+
 
 cuemb_embedding.register_autograd(cuembed_backward, setup_context=setup_context)

--- a/examples/pytorch/cuembed_test.py
+++ b/examples/pytorch/cuembed_test.py
@@ -4,6 +4,14 @@ from cuembed_pyt import cuemb_embedding
 
 torch.manual_seed(0)
 
+class CuEmbedModule(nn.Module):
+    def __init__(self, weight):
+        super().__init__()
+        self.weight = weight
+
+    def forward(self, indices, offsets):
+        return cuemb_embedding(self.weight, indices, offsets)
+
 def test_cuembed(embedding_bag, indices, offsets, weights):
     if(weights != None):
         res = cuemb_embedding(embedding_bag.weight, indices, offsets, weights)
@@ -24,6 +32,43 @@ def test_cuembed(embedding_bag, indices, offsets, weights):
 
     # might not be exactly equal because cuEmbed uses atomics in back pass
     print('bprop test pass = ', torch.allclose(grad_res, grad_ref), '\n')
+
+def test_cuembed_compile():
+    print("\nTesting cuembed with torch.compile...")
+
+    # Create a simple embedding bag
+    k = 15  # num_embeddings
+    d = 2   # embedding_dim
+    batch_size = 256
+
+    # Create indices and offsets
+    indices = torch.randint(0, k, (batch_size,), device='cuda', dtype=torch.long)
+    offsets = torch.arange(0, batch_size + 1, device='cuda', dtype=torch.long)
+
+    # Create embedding bag
+    embedding_bag = nn.EmbeddingBag(
+        num_embeddings=k,
+        embedding_dim=d,
+        mode='sum',
+        include_last_offset=True,
+        padding_idx=None,
+        dtype=torch.float32
+    ).to(device='cuda')
+
+    # Create and compile the module
+    cuembed_module = CuEmbedModule(embedding_bag.weight)
+    compiled_module = torch.compile(cuembed_module)
+
+    # Test forward pass with no_grad
+    with torch.no_grad():
+        res = compiled_module(indices, offsets)
+        ref = embedding_bag(indices, offsets)
+
+    # Verify shapes and values
+    print(f"Expected shape: [{batch_size}, {d}]")
+    print(f"Actual shape: {res.shape}")
+    print(f"Shape test pass: {res.shape == ref.shape}")
+    print(f"Value test pass: {torch.allclose(res, ref)}")
 
 # test cases
 k = 958
@@ -65,3 +110,6 @@ weights = torch.rand([n], device='cuda', dtype=torch.float32)
 
 test_cuembed(embedding_bag, indices, offsets, weights)
 test_cuembed(embedding_bag, indices, offsets, None)
+
+# Run compile test
+test_cuembed_compile()


### PR DESCRIPTION
- Fake implementation of cuemb_embedding had incorrect calculation of output size
- Re-implemented using batch size and embedding dimension directly
- Added a test for this case which compiles using torch.compile 
- The file seemed to be in dos format instead of unix, so that has changed as well