### PR TITLE
Feature/narrow embed heuristics

### DIFF
--- a/cuembed/include/embedding_lookup.cuh
+++ b/cuembed/include/embedding_lookup.cuh
@@ -165,8 +165,8 @@ std::tuple<int, int> DivideRowIntoVectors(const int embed_width) {
   // Targeting LDG.E.128 for each load instruction.
   // Thus requiring each load to be 16 bytes.
   // If not possible, reduce the load width.
-  int bytes_per_load = 16;
-  if (bytes_per_row % 16 == 0) {
+  int bytes_per_load = 8;
+  if ((bytes_per_row % 16 == 0) && (bytes_per_row > 64)) {
     bytes_per_load = 16;
   } else if (bytes_per_row % 8 == 0) {
     bytes_per_load = 8;

--- a/cuembed/include/embedding_lookup.cuh
+++ b/cuembed/include/embedding_lookup.cuh
@@ -270,7 +270,7 @@ void EmbeddingForward(const InputT* params,
 
   auto [element_per_load, threads_per_sample, samples_per_cta] =
       GetKernelLaunchParams<ElemT, IndexT>(
-          embed_width, num_hots, weights == nullptr);
+          embed_width, num_hots, weights != nullptr);
   dim3 launch_block(embed_width / element_per_load, samples_per_cta, 1);
   dim3 launch_grid((batch_size + samples_per_cta - 1) / samples_per_cta, 1, 1);
   size_t smem_size = samples_per_cta * num_hots * sizeof(IndexT);


### PR DESCRIPTION
for narrow embeddings (narrow = less than 64B), use LDG.64 (float2, 8B) per thread rather than LDG.128

<img width="1800" height="600" alt="app_bw_speedup" src="https://github.com/user-attachments/assets/7898d3ab-5c91-4ca2-821d-9bbbcf5efccf" />
[interactive plot](https://drive.google.com/file/d/1AnYsInhGHejRIwZ7SlBeIN_9b4CH2FQt/view?usp=drive_link) (open in browser)